### PR TITLE
Separate index for signer history

### DIFF
--- a/es/indicies.go
+++ b/es/indicies.go
@@ -298,7 +298,8 @@ const signersIndex = `
 				"weight": { "type": "integer" },
 				"seq": { "type": "integer" },
 				"tx_idx": { "type": "integer" },
-				"idx": { "type": "integer" }
+				"idx": { "type": "integer" },
+				"created_at": { "type": "date" }
 			}
 		}
 	}

--- a/es/indicies.go
+++ b/es/indicies.go
@@ -167,7 +167,8 @@ const opIndex = `
 				"signer": {
 					"properties": {
 						"key": { "type": "keyword" },
-						"weight": { "type": "byte" }
+						"weight": { "type": "byte" },
+						"type": { "type": "byte" }
 					}
 				},
 				"data": {
@@ -294,8 +295,8 @@ const signerHistoryIndex = `
 				"paging_token": { "type": "keyword", "index": true },
 				"account_id": { "type": "keyword", "index": true },
 				"signer": { "type": "keyword", "index": true },
-				"type": { "type": "integer" },
-				"weight": { "type": "integer" },
+				"type": { "type": "byte" },
+				"weight": { "type": "byte" },
 				"seq": { "type": "integer" },
 				"tx_idx": { "type": "integer" },
 				"idx": { "type": "integer" },

--- a/es/indicies.go
+++ b/es/indicies.go
@@ -281,6 +281,29 @@ const tradesIndex = `
 	}
 `
 
+const signersIndex = `
+	{
+		"settings": {
+			"index" : {
+        "sort.field" : "paging_token",
+        "sort.order" : "desc"
+			}
+		},
+		"mappings": {
+			"properties": {
+				"paging_token": { "type": "keyword", "index": true },
+				"account_id": { "type": "keyword", "index": true },
+				"signer": { "type": "keyword", "index": true },
+				"type": { "type": "integer" },
+				"weight": { "type": "integer" },
+				"seq": { "type": "integer" },
+				"tx_idx": { "type": "integer" },
+				"idx": { "type": "integer" }
+			}
+		}
+	}
+`
+
 // CreateIndicies creates all indicies in ElasticSearch database
 func CreateIndicies() {
 	refreshIndex(ledgerHeaderIndexName, ledgerHeaderIndex)
@@ -288,6 +311,7 @@ func CreateIndicies() {
 	refreshIndex(opIndexName, opIndex)
 	refreshIndex(balanceIndexName, balanceIndex)
 	refreshIndex(tradesIndexName, tradesIndex)
+	refreshIndex(signersIndexName, signersIndex)
 }
 
 func refreshIndex(name string, body string) {

--- a/es/indicies.go
+++ b/es/indicies.go
@@ -244,8 +244,15 @@ const balanceIndex = `
 
 const tradesIndex = `
 	{
+		"settings": {
+			"index" : {
+        "sort.field" : "paging_token",
+        "sort.order" : "desc"
+			}
+		},
 		"mappings": {
 			"properties": {
+				"paging_token": { "type": "keyword", "index": true },				
 				"sold": { "type": "scaled_float", "scaling_factor": 10000000 },
 				"bought": { "type": "scaled_float", "scaling_factor": 10000000 },
 				"asset_sold": {

--- a/es/indicies.go
+++ b/es/indicies.go
@@ -281,7 +281,7 @@ const tradesIndex = `
 	}
 `
 
-const signersIndex = `
+const signerHistoryIndex = `
 	{
 		"settings": {
 			"index" : {
@@ -299,7 +299,7 @@ const signersIndex = `
 				"seq": { "type": "integer" },
 				"tx_idx": { "type": "integer" },
 				"idx": { "type": "integer" },
-				"created_at": { "type": "date" }
+				"ledger_close_time": { "type": "date" }
 			}
 		}
 	}
@@ -312,7 +312,7 @@ func CreateIndicies() {
 	refreshIndex(opIndexName, opIndex)
 	refreshIndex(balanceIndexName, balanceIndex)
 	refreshIndex(tradesIndexName, tradesIndex)
-	refreshIndex(signersIndexName, signersIndex)
+	refreshIndex(signerHistoryIndexName, signerHistoryIndex)
 }
 
 func refreshIndex(name string, body string) {

--- a/es/ledger_serializer.go
+++ b/es/ledger_serializer.go
@@ -62,6 +62,29 @@ func (s *ledgerSerializer) serializeOperations(transactionRow db.TxHistoryRow, t
 			}
 
 			s.serializeTrades(result, transaction, operation)
+
+			if operation.Signer != nil {
+				token := PagingToken{
+					LedgerSeq:        s.ledger.Seq,
+					TransactionOrder: transaction.Index,
+					OperationOrder:   operation.Index,
+					EffectGroup:      SignerHistoryEffectPagingTokenGroup,
+				}
+
+				entry := &SignerHistory{
+					PagingToken:     token,
+					AccountID:       operation.SourceAccountID,
+					Signer:          operation.Signer.Key,
+					Type:            0,
+					Weight:          operation.Signer.Weight,
+					TxIndex:         transaction.Index,
+					Index:           operation.Index,
+					Seq:             s.ledger.Seq,
+					LedgerCloseTime: s.ledger.CloseTime,
+				}
+
+				SerializeForBulk(entry, s.buffer)
+			}
 		}
 	}
 }

--- a/es/ledger_serializer.go
+++ b/es/ledger_serializer.go
@@ -63,27 +63,9 @@ func (s *ledgerSerializer) serializeOperations(transactionRow db.TxHistoryRow, t
 
 			s.serializeTrades(result, transaction, operation)
 
-			if operation.Signer != nil {
-				token := PagingToken{
-					LedgerSeq:        s.ledger.Seq,
-					TransactionOrder: transaction.Index,
-					OperationOrder:   operation.Index,
-					EffectGroup:      SignerHistoryEffectPagingTokenGroup,
-				}
-
-				entry := &SignerHistory{
-					PagingToken:     token,
-					AccountID:       operation.SourceAccountID,
-					Signer:          operation.Signer.Key,
-					Type:            0,
-					Weight:          operation.Signer.Weight,
-					TxIndex:         transaction.Index,
-					Index:           operation.Index,
-					Seq:             s.ledger.Seq,
-					LedgerCloseTime: s.ledger.CloseTime,
-				}
-
-				SerializeForBulk(entry, s.buffer)
+			h := ProduceSignerHistory(operation)
+			if h != nil {
+				SerializeForBulk(h, s.buffer)
 			}
 		}
 	}

--- a/es/main.go
+++ b/es/main.go
@@ -11,7 +11,7 @@ var txIndexName = "tx"
 var opIndexName = "op"
 var balanceIndexName = "balance"
 var tradesIndexName = "trades"
-var signersIndexName = "signers"
+var signerHistoryIndexName = "signers"
 
 // Indexable represents object that can be indexed for ElasticSearch
 type Indexable interface {

--- a/es/main.go
+++ b/es/main.go
@@ -11,6 +11,7 @@ var txIndexName = "tx"
 var opIndexName = "op"
 var balanceIndexName = "balance"
 var tradesIndexName = "trades"
+var signersIndexName = "signers"
 
 // Indexable represents object that can be indexed for ElasticSearch
 type Indexable interface {

--- a/es/paging_token.go
+++ b/es/paging_token.go
@@ -30,6 +30,9 @@ var (
 
 	// TradeEffectPagingTokenGroup represent trade effects
 	TradeEffectPagingTokenGroup = 3
+
+	// SignerHistoryEffectPagingTokenGroup represent signer effects
+	SignerHistoryEffectPagingTokenGroup = 4
 )
 
 // String returns string representation of order

--- a/es/signer.go
+++ b/es/signer.go
@@ -6,6 +6,7 @@ import "github.com/stellar/go/xdr"
 type Signer struct {
 	Key    string `json:"key"`
 	Weight int    `json:"weight"`
+	Type   int    `json:"type"`
 }
 
 // NewSigner returns new Signer
@@ -17,5 +18,6 @@ func NewSigner(signer *xdr.Signer) *Signer {
 	return &Signer{
 		signer.Key.Address(),
 		int(signer.Weight),
+		int(signer.Key.Type),
 	}
 }

--- a/es/signer_history.go
+++ b/es/signer_history.go
@@ -4,7 +4,7 @@ import (
 	"time"
 )
 
-// SignerHistory represents trade entry
+// SignerHistory represents signer change entry, still the question if it is required
 type SignerHistory struct {
 	PagingToken     PagingToken `json:"paging_token"`
 	AccountID       string      `json:"account_id"`
@@ -15,6 +15,36 @@ type SignerHistory struct {
 	Index           int         `json:"idx"`
 	Seq             int         `json:"seq"`
 	LedgerCloseTime time.Time   `json:"ledger_close_time"`
+}
+
+// ProduceSignerHistory creates new signer history entry
+func ProduceSignerHistory(o *Operation) (h *SignerHistory) {
+	s := o.Signer
+
+	if s == nil {
+		return nil
+	}
+
+	token := PagingToken{
+		LedgerSeq:        o.Seq,
+		TransactionOrder: o.TxIndex,
+		OperationOrder:   o.Index,
+		EffectGroup:      SignerHistoryEffectPagingTokenGroup,
+	}
+
+	entry := &SignerHistory{
+		PagingToken:     token,
+		AccountID:       o.SourceAccountID,
+		Signer:          o.Signer.Key,
+		Type:            o.Signer.Type,
+		Weight:          o.Signer.Weight,
+		TxIndex:         o.TxIndex,
+		Index:           o.Index,
+		Seq:             o.Seq,
+		LedgerCloseTime: o.CloseTime,
+	}
+
+	return entry
 }
 
 // DocID balance es document id

--- a/es/signer_history.go
+++ b/es/signer_history.go
@@ -1,0 +1,29 @@
+package es
+
+import (
+	"time"
+)
+
+// SignerHistory represents trade entry
+type SignerHistory struct {
+	PagingToken     PagingToken `json:"paging_token"`
+	AccountID       string      `json:"account_id"`
+	Signer          string      `json:"signer"`
+	Type            int         `json:"type"`
+	Weight          int         `json:"weight"`
+	TxIndex         int         `json:"tx_idx"`
+	Index           int         `json:"idx"`
+	Seq             int         `json:"seq"`
+	LedgerCloseTime time.Time   `json:"ledger_close_time"`
+}
+
+// DocID balance es document id
+func (t *SignerHistory) DocID() *string {
+	s := t.PagingToken.String()
+	return &s
+}
+
+// IndexName balances index name
+func (t *SignerHistory) IndexName() string {
+	return signerHistoryIndexName
+}


### PR DESCRIPTION
In the sake of decomposition!

Signers index is the small piece of operations index, all the same information could be retrieved from operations as well, but I think it is still useful, as it will be smaller => faster.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/astroband/astrologer/14)
<!-- Reviewable:end -->
