### PR TITLE
Get rid of effect group part in paging tokens

### DIFF
--- a/es/balance_extractor.go
+++ b/es/balance_extractor.go
@@ -98,8 +98,6 @@ func (e *BalanceExtractor) created(change xdr.LedgerEntryChange) {
 
 func (e *BalanceExtractor) updated(change xdr.LedgerEntryChange) {
 	updated := change.MustUpdated().Data
-	e.index++
-	pagingToken := PagingToken{EffectIndex: e.index}.Merge(e.basePagingToken)
 
 	switch x := updated.Type; x {
 	case xdr.LedgerEntryTypeAccount:
@@ -109,6 +107,8 @@ func (e *BalanceExtractor) updated(change xdr.LedgerEntryChange) {
 
 		if oldBalance != account.Balance {
 			diff := account.Balance - oldBalance
+			e.index++
+			pagingToken := PagingToken{EffectIndex: e.index}.Merge(e.basePagingToken)
 
 			e.balances = append(
 				e.balances,
@@ -122,6 +122,8 @@ func (e *BalanceExtractor) updated(change xdr.LedgerEntryChange) {
 
 		if oldBalance != line.Balance {
 			diff := line.Balance - oldBalance
+			e.index++
+			pagingToken := PagingToken{EffectIndex: e.index}.Merge(e.basePagingToken)
 
 			e.balances = append(
 				e.balances,

--- a/es/paging_token.go
+++ b/es/paging_token.go
@@ -11,7 +11,6 @@ type PagingToken struct {
 	LedgerSeq        int
 	TransactionOrder int
 	OperationOrder   int
-	EffectGroup      int
 	EffectIndex      int
 }
 
@@ -19,20 +18,7 @@ var (
 	ledgerFormat      = "%012d"
 	transactionFormat = "%04d"
 	operationFormat   = "%04d"
-	effectGroupFormat = "%04d"
 	effectIndexFormat = "%04d"
-
-	// BalanceEffectPagingTokenGroup represents balance entry taken from result meta
-	BalanceEffectPagingTokenGroup = 1
-
-	// FeeEffectPagingTokenGroup represents balance entry taken from fee meta
-	FeeEffectPagingTokenGroup = 2
-
-	// TradeEffectPagingTokenGroup represent trade effects
-	TradeEffectPagingTokenGroup = 3
-
-	// SignerHistoryEffectPagingTokenGroup represent signer effects
-	SignerHistoryEffectPagingTokenGroup = 4
 )
 
 // String returns string representation of order
@@ -40,7 +26,6 @@ func (o PagingToken) String() (result string) {
 	return fmt.Sprintf(ledgerFormat, o.LedgerSeq) + "-" +
 		fmt.Sprintf(transactionFormat, o.TransactionOrder) + "-" +
 		fmt.Sprintf(operationFormat, o.OperationOrder) + "-" +
-		fmt.Sprintf(effectGroupFormat, o.EffectGroup) + "-" +
 		fmt.Sprintf(effectIndexFormat, o.EffectIndex)
 }
 
@@ -67,12 +52,6 @@ func (o PagingToken) Merge(n PagingToken) (result PagingToken) {
 		result.OperationOrder = o.OperationOrder
 	} else {
 		result.OperationOrder = n.OperationOrder
-	}
-
-	if o.EffectGroup != 0 {
-		result.EffectGroup = o.EffectGroup
-	} else {
-		result.EffectGroup = n.EffectGroup
 	}
 
 	if o.EffectIndex != 0 {

--- a/es/serialize.go
+++ b/es/serialize.go
@@ -15,14 +15,14 @@ func SerializeForBulk(obj Indexable, b *bytes.Buffer) {
 
 	if id != nil {
 		meta = fmt.Sprintf(
-			`{ "index": { "_index": "%s", "_id": "%s", "_type": "_doc" } }%s`,
+			`{ "create": { "_index": "%s", "_id": "%s", "_type": "_doc" } }%s`,
 			obj.IndexName(),
 			*id,
 			"\n",
 		)
 	} else {
 		meta = fmt.Sprintf(
-			`{ "index": { "_index": "%s", "_type": "_doc" } }%s`, obj.IndexName(), "\n",
+			`{ "create": { "_index": "%s", "_type": "_doc" } }%s`, obj.IndexName(), "\n",
 		)
 	}
 

--- a/es/signer_history.go
+++ b/es/signer_history.go
@@ -29,7 +29,6 @@ func ProduceSignerHistory(o *Operation) (h *SignerHistory) {
 		LedgerSeq:        o.Seq,
 		TransactionOrder: o.TxIndex,
 		OperationOrder:   o.Index,
-		EffectGroup:      SignerHistoryEffectPagingTokenGroup,
 	}
 
 	entry := &SignerHistory{

--- a/es/trade_extractor.go
+++ b/es/trade_extractor.go
@@ -18,12 +18,13 @@ type TradeExtractor struct {
 }
 
 // ProduceTrades returns trades
-func ProduceTrades(r *xdr.OperationResult, op *Operation, closeTime time.Time, pagingToken PagingToken) (trades []Trade) {
+func ProduceTrades(r *xdr.OperationResult, op *Operation, closeTime time.Time, pagingToken PagingToken, startIndex int) (trades []Trade) {
 	extractor := &TradeExtractor{
 		result:      r,
 		closeTime:   closeTime,
 		pagingToken: pagingToken,
 		operation:   op,
+		tokenIndex:  startIndex,
 	}
 
 	if extractor == nil {
@@ -130,7 +131,7 @@ func (e *TradeExtractor) fetchFromPathPaymentStrictSend(result xdr.PathPaymentSt
 
 func (e *TradeExtractor) fetchClaims(claims []xdr.ClaimOfferAtom, accountID string) (trades []Trade) {
 	for _, claim := range claims {
-		pagingTokenA := PagingToken{EffectGroup: TradeEffectPagingTokenGroup, EffectIndex: e.tokenIndex + 1}.Merge(e.pagingToken)
+		pagingTokenA := PagingToken{EffectIndex: e.tokenIndex + 1}.Merge(e.pagingToken)
 
 		tradeA := Trade{
 			PagingToken:     pagingTokenA,
@@ -138,7 +139,7 @@ func (e *TradeExtractor) fetchClaims(claims []xdr.ClaimOfferAtom, accountID stri
 			LedgerCloseTime: e.closeTime,
 		}
 
-		pagingTokenB := PagingToken{EffectGroup: TradeEffectPagingTokenGroup, EffectIndex: e.tokenIndex + 2}.Merge(e.pagingToken)
+		pagingTokenB := PagingToken{EffectIndex: e.tokenIndex + 2}.Merge(e.pagingToken)
 
 		tradeB := Trade{
 			PagingToken:     pagingTokenB,


### PR DESCRIPTION
Here's an attempt to get rid of `EffectGroup` component in our paging tokens (ids, in fact). It would help us to save some space on the disk

The idea is simple: trades indices start from the last balance effect index, so their ids won't overlap

Also, we had a little bug, which caused balances ids to have gaps. I fixed that in this PR too

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/astroband/astrologer/17)
<!-- Reviewable:end -->
