### PR TITLE
Fill gaps command

### DIFF
--- a/commands/es-stats.go
+++ b/commands/es-stats.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"log"
 	"os"
 	"strconv"
 
@@ -17,10 +18,15 @@ type EsStatsCommand struct {
 
 // Execute collects ledger staticstics for the current ES cluster
 func (cmd *EsStatsCommand) Execute() {
+	min, max, empty := cmd.ES.MinMaxSeq()
+
+	if empty {
+		log.Println("ES is empty")
+		return
+	}
+
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetHeader([]string{"From", "To", "Doc_count"})
-
-	min, max := cmd.ES.MinMaxSeq()
 	buckets := cmd.esRanges(min, max)
 
 	for i := 0; i < len(buckets); i++ {

--- a/commands/export.go
+++ b/commands/export.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"bytes"
+	"io/ioutil"
 	"log"
 	"math/rand"
 	"time"
@@ -79,6 +80,7 @@ func (cmd *ExportCommand) exportBlock(i int) {
 	}
 
 	if !cmd.Config.DryRun {
+		ioutil.WriteFile("./bulk.json", b.Bytes(), 0644)
 		cmd.ES.IndexWithRetries(&b, cmd.Config.RetryCount)
 	}
 }

--- a/commands/export.go
+++ b/commands/export.go
@@ -86,9 +86,12 @@ func (cmd *ExportCommand) exportBlock(i int) {
 }
 
 func (cmd *ExportCommand) index(b *bytes.Buffer, retry int) {
-	indexed := cmd.ES.BulkInsert(b)
+	err := cmd.ES.BulkInsert(b)
 
-	if !indexed {
+	if err != nil {
+		log.Println(err)
+		log.Println("Failed, retrying")
+
 		if retry > cmd.Config.RetryCount {
 			log.Fatal("Retries for bulk failed, aborting")
 		}

--- a/commands/fill_gaps.go
+++ b/commands/fill_gaps.go
@@ -1,0 +1,145 @@
+package commands
+
+import (
+	"bytes"
+	"github.com/astroband/astrologer/db"
+	"github.com/astroband/astrologer/es"
+	"github.com/astroband/astrologer/support"
+	"log"
+)
+
+const batchSize = 100
+const INDEX_RETRIES_COUNT = 25
+
+type FillGapsCommandConfig struct {
+	DryRun bool
+	Start  *int
+	Count  *int
+}
+
+type FillGapsCommand struct {
+	ES     es.Adapter
+	DB     db.Adapter
+	Config *FillGapsCommandConfig
+
+	minSeq int
+	maxSeq int
+	count  int
+}
+
+func (cmd *FillGapsCommand) Execute() {
+	if cmd.Config.Start != nil && cmd.Config.Count != nil {
+		cmd.minSeq = *cmd.Config.Start
+		cmd.count = *cmd.Config.Count
+		cmd.maxSeq = cmd.minSeq + cmd.count
+	} else {
+		var empty bool
+		cmd.minSeq, cmd.maxSeq, empty = cmd.ES.MinMaxSeq()
+
+		if empty {
+			log.Println("ES is empty")
+			return
+		}
+
+		if cmd.Config.Start != nil {
+			cmd.minSeq = *cmd.Config.Start
+			cmd.count = cmd.maxSeq - cmd.minSeq + 1
+		}
+	}
+
+	log.Printf("Min seq is %d, max seq is %d\n", cmd.minSeq, cmd.maxSeq)
+
+	var missing []int
+
+	for i := cmd.minSeq; i < cmd.maxSeq; i += batchSize {
+		to := i + batchSize
+		if to > cmd.maxSeq {
+			to = cmd.maxSeq
+		}
+
+		// log.Println(i, to)
+		seqs := cmd.ES.GetLedgerSeqsInRange(i, to)
+		// log.Println("Seqs ingested:", seqs)
+
+		if len(seqs) > 0 {
+			missing = append(missing, cmd.findMissing(seqs)...)
+		} else {
+			missing = append(missing, support.MakeRange(i-1, to)...)
+		}
+		// log.Println("=============================")
+	}
+
+	log.Println(missing)
+	log.Println(len(missing))
+
+	if !cmd.Config.DryRun {
+		cmd.exportSeqs(missing)
+	}
+}
+
+func (cmd *FillGapsCommand) findMissing(sortedArr []int) (missing []int) {
+	for i := 1; i < len(sortedArr); i += 1 {
+		diff := sortedArr[i] - sortedArr[i-1]
+		if diff > 1 {
+			missing = append(missing, support.MakeRange(sortedArr[i-1], sortedArr[i])...)
+		}
+	}
+
+	// log.Println("Missing:", missing)
+	return
+}
+
+func (cmd *FillGapsCommand) exportSeqs(seqs []int) {
+	// exportConfig := ExportCommandConfig{
+	// 	Start: config.NumberWithSign{Value: cmd.minSeq, Explicit: false},
+	// 	Count: cmd.count,
+	// }
+
+	// exportCommand = &cmd.ExportCommand{ES: cmd.ES, DB: cmd.DB, Config: exportConfig}
+	log.Printf("Exporting %d ledgers\n", len(seqs))
+
+	var dbSeqs []int
+	var b bytes.Buffer
+	batch := 50
+
+	for i := 0; i < len(seqs); i += batch {
+		b.Reset()
+
+		to := i + batch
+		if to > len(seqs) {
+			to = len(seqs) - 1
+		}
+
+		var seqsBlock []int
+
+		if len(seqs) == 1 {
+			seqsBlock = seqs
+		} else {
+			seqsBlock = seqs[i:to]
+		}
+
+		pool.Submit(func() {
+			rows := cmd.DB.LedgerHeaderRowFetchBySeqs(seqsBlock)
+
+			for n := 0; n < len(rows); n++ {
+				log.Printf("Ingesting %d ledger\n", rows[n].LedgerSeq)
+				dbSeqs = append(dbSeqs, rows[n].LedgerSeq)
+
+				txs := cmd.DB.TxHistoryRowForSeq(rows[n].LedgerSeq)
+				fees := cmd.DB.TxFeeHistoryRowsForRows(txs)
+
+				es.SerializeLedger(rows[n], txs, fees, &b)
+			}
+
+			log.Println("Calling bulk insert")
+			cmd.ES.IndexWithRetries(&b, INDEX_RETRIES_COUNT)
+		})
+	}
+
+	pool.StopWait()
+	diff := support.Difference(seqs, dbSeqs)
+
+	if len(diff) > 0 {
+		log.Printf("DB misses next ledgers: %v", diff)
+	}
+}

--- a/commands/fill_gaps_test.go
+++ b/commands/fill_gaps_test.go
@@ -1,0 +1,18 @@
+package commands
+
+import (
+	"github.com/astroband/astrologer/es/mocks"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestFillGaps(t *testing.T) {
+	t.Error("test error")
+
+	esClient := new(mocks.EsAdapter)
+	esClient.On("MinMaxSeq").Return(386, 411)
+
+	missingSeqs := FillGaps(esClient)
+
+	assert.NotEmpty(t, missingSeqs)
+}

--- a/config/main.go
+++ b/config/main.go
@@ -22,6 +22,7 @@ var (
 	ingestCommand      = kingpin.Command("ingest", "Start real time ingestion")
 	_                  = kingpin.Command("stats", "Print database ledger statistics")
 	_                  = kingpin.Command("es-stats", "Print ES ranges stats")
+	fillGapsCommand    = kingpin.Command("fill-gaps", "Fill gaps")
 
 	// DatabaseURL Stellar Core database URL
 	DatabaseURL = kingpin.
@@ -72,11 +73,14 @@ var (
 	// Verbose print data
 	Verbose = exportCommand.Flag("verbose", "Print indexed data").Bool()
 
-	// ExportDryRun do not index data
-	ExportDryRun = exportCommand.Flag("dry-run", "Do not send actual data to Elastic").Bool()
+	// DryRun do not index data
+	DryRun = kingpin.Flag("dry-run", "Do not send actual data to Elastic").Bool()
 
 	// ForceRecreateIndexes Allows indexes to be deleted before creation
 	ForceRecreateIndexes = createIndexCommand.Flag("force", "Delete indexes before creation").Bool()
+
+	FillGapsFrom  = fillGapsCommand.Arg("start", "Ledger to start from").Int()
+	FillGapsCount = fillGapsCommand.Arg("count", "How many ledgers to check").Int()
 )
 
 func parseNumberWithSign(value string) (r NumberWithSign, err error) {

--- a/config/main.go
+++ b/config/main.go
@@ -79,8 +79,13 @@ var (
 	// ForceRecreateIndexes Allows indexes to be deleted before creation
 	ForceRecreateIndexes = createIndexCommand.Flag("force", "Delete indexes before creation").Bool()
 
-	FillGapsFrom  = fillGapsCommand.Arg("start", "Ledger to start from").Int()
-	FillGapsCount = fillGapsCommand.Arg("count", "How many ledgers to check").Int()
+	FillGapsFrom      = fillGapsCommand.Arg("start", "Ledger to start from").Int()
+	FillGapsCount     = fillGapsCommand.Arg("count", "How many ledgers to check").Int()
+	FillGapsBatchSize = fillGapsCommand.
+				Flag("batch", "Ledger batch size").
+				Short('b').
+				Default("50").
+				Int()
 )
 
 func parseNumberWithSign(value string) (r NumberWithSign, err error) {

--- a/db/ledger_header_row.go
+++ b/db/ledger_header_row.go
@@ -2,9 +2,9 @@ package db
 
 import (
 	"database/sql"
-	"log"
-
+	"github.com/jmoiron/sqlx"
 	"github.com/stellar/go/xdr"
+	"log"
 )
 
 // LedgerHeaderRow is struct representing ledger in database
@@ -105,6 +105,25 @@ func (db *Client) LedgerHeaderNext(seq int) *LedgerHeaderRow {
 	}
 
 	return &h
+}
+
+func (db *Client) LedgerHeaderRowFetchBySeqs(seqs []int) []LedgerHeaderRow {
+	ledgers := []LedgerHeaderRow{}
+
+	query, args, err := sqlx.In("SELECT * FROM ledgerheaders WHERE ledgerseq IN (?) ORDER BY ledgerseq ASC;", seqs)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	query = db.rawClient.Rebind(query)
+	err = db.rawClient.Select(&ledgers, query, args...)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return ledgers
 }
 
 // LedgerHeaderGaps returns gap positions in ledgerheaders

--- a/db/main.go
+++ b/db/main.go
@@ -40,6 +40,7 @@ func utf8Scrub(in string) string {
 type Adapter interface {
 	LedgerHeaderRowCount(first int, last int) int
 	LedgerHeaderRowFetchBatch(n int, start int, batchSize int) []LedgerHeaderRow
+	LedgerHeaderRowFetchBySeqs(seqs []int) []LedgerHeaderRow
 	LedgerHeaderLastRow() *LedgerHeaderRow
 	LedgerHeaderFirstRow() *LedgerHeaderRow
 	LedgerHeaderNext(seq int) *LedgerHeaderRow

--- a/es/adapter.go
+++ b/es/adapter.go
@@ -170,7 +170,7 @@ func (es *Client) GetLedgerSeqsInRange(min, max int) (seqs []int) {
 			"range": map[string]interface{}{
 				"seq": map[string]interface{}{
 					"gte": min,
-					"lt":  max,
+					"lte": max,
 				},
 			},
 		},

--- a/es/main.go
+++ b/es/main.go
@@ -22,7 +22,7 @@ type Adapter interface {
 	IndexExists(name IndexName) bool
 	CreateIndex(name IndexName, body IndexDefinition)
 	DeleteIndex(name IndexName)
-	BulkInsert(payload *bytes.Buffer) (success bool)
+	BulkInsert(payload *bytes.Buffer) error
 	IndexWithRetries(payload *bytes.Buffer, retriesCount int)
 }
 

--- a/es/main.go
+++ b/es/main.go
@@ -15,7 +15,7 @@ type Indexable interface {
 
 // Adapter represents the ledger storage backend
 type Adapter interface {
-	MinMaxSeq() (min, max int)
+	MinMaxSeq() (min, max int, empty bool)
 	LedgerSeqRangeQuery(ranges []map[string]interface{}) map[string]interface{}
 	GetLedgerSeqsInRange(min, max int) []int
 	LedgerCountInRange(min, max int) int

--- a/main.go
+++ b/main.go
@@ -6,6 +6,8 @@ import (
 	"github.com/astroband/astrologer/db"
 	"github.com/astroband/astrologer/es"
 	"gopkg.in/alecthomas/kingpin.v2"
+	"log"
+	"time"
 )
 
 func main() {
@@ -28,7 +30,7 @@ func main() {
 		config := cmd.ExportCommandConfig{
 			Start:      cfg.Start,
 			Count:      *cfg.Count,
-			DryRun:     *cfg.ExportDryRun,
+			DryRun:     *cfg.DryRun,
 			RetryCount: *cfg.Retries,
 			BatchSize:  *cfg.BatchSize,
 		}
@@ -38,7 +40,19 @@ func main() {
 		command = &cmd.IngestCommand{ES: esClient, DB: dbClient}
 	case "es-stats":
 		command = &cmd.EsStatsCommand{ES: esClient}
+	case "fill-gaps":
+		dbClient := db.Connect(*cfg.DatabaseUrl)
+		config := &cmd.FillGapsCommandConfig{
+			DryRun: *cfg.DryRun,
+			Start:  cfg.FillGapsFrom,
+			Count:  cfg.FillGapsCount,
+		}
+		command = &cmd.FillGapsCommand{ES: esClient, DB: dbClient, Config: config}
 	}
 
+	start := time.Now()
 	command.Execute()
+	elapsed := time.Since(start)
+
+	log.Printf("Command took %s", elapsed)
 }

--- a/main.go
+++ b/main.go
@@ -43,9 +43,10 @@ func main() {
 	case "fill-gaps":
 		dbClient := db.Connect(*cfg.DatabaseUrl)
 		config := &cmd.FillGapsCommandConfig{
-			DryRun: *cfg.DryRun,
-			Start:  cfg.FillGapsFrom,
-			Count:  cfg.FillGapsCount,
+			DryRun:    *cfg.DryRun,
+			Start:     cfg.FillGapsFrom,
+			Count:     cfg.FillGapsCount,
+			BatchSize: cfg.FillGapsBatchSize,
 		}
 		command = &cmd.FillGapsCommand{ES: esClient, DB: dbClient, Config: config}
 	}

--- a/support/main.go
+++ b/support/main.go
@@ -29,10 +29,30 @@ func Unique(arr []int) []int {
 
 //Creates (from, to) range slice
 // e.g. for 4, 7 returns [5, 6]
-func MakeRange(from, to int) []int {
-	a := make([]int, to-from-1)
+func MakeRangeGtLt(gt, lt int) []int {
+	a := make([]int, lt-gt-1)
 	for i := range a {
-		a[i] = from + 1 + i
+		a[i] = gt + 1 + i
+	}
+	return a
+}
+
+//Creates (from, to] range slice
+// e.g. for 4, 7 returns [5, 6, 7]
+func MakeRangeGtLte(gt, lte int) []int {
+	a := make([]int, lte-gt)
+	for i := range a {
+		a[i] = gt + 1 + i
+	}
+	return a
+}
+
+//Creates [from, to) range slice
+// e.g. for 4, 7 returns [4, 5, 6]
+func MakeRangeGteLt(gte, lt int) []int {
+	a := make([]int, lt-gte)
+	for i := range a {
+		a[i] = gte + i
 	}
 	return a
 }

--- a/support/main.go
+++ b/support/main.go
@@ -1,5 +1,9 @@
 package support
 
+import (
+	"fmt"
+)
+
 func Difference(a, b []int) (diff []int) {
 	m := make(map[int]bool)
 
@@ -55,4 +59,27 @@ func MakeRangeGteLt(gte, lt int) []int {
 		a[i] = gte + i
 	}
 	return a
+}
+
+//Creates [from, to] range slice
+// e.g. for 4, 7 returns [4, 5, 6, 7]
+func MakeRangeGteLte(gte, lte int) []int {
+	a := make([]int, lte-gte+1)
+	for i := range a {
+		a[i] = gte + i
+	}
+	return a
+}
+
+func ByteCountBinary(b int) string {
+	const unit = 1024
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := int64(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %ciB", float64(b)/float64(div), "KMGTPE"[exp])
 }

--- a/support/main.go
+++ b/support/main.go
@@ -1,0 +1,38 @@
+package support
+
+func Difference(a, b []int) (diff []int) {
+	m := make(map[int]bool)
+
+	for _, item := range b {
+		m[item] = true
+	}
+
+	for _, item := range a {
+		if _, ok := m[item]; !ok {
+			diff = append(diff, item)
+		}
+	}
+	return
+}
+
+func Unique(arr []int) []int {
+	keys := make(map[int]bool)
+	res := []int{}
+	for _, entry := range arr {
+		if _, value := keys[entry]; !value {
+			keys[entry] = true
+			res = append(res, entry)
+		}
+	}
+	return res
+}
+
+//Creates (from, to) range slice
+// e.g. for 4, 7 returns [5, 6]
+func MakeRange(from, to int) []int {
+	a := make([]int, to-from-1)
+	for i := range a {
+		a[i] = from + 1 + i
+	}
+	return a
+}


### PR DESCRIPTION
This PR adds `fill-gaps` command to Astrologer, which....well...fill gaps!

`astrologer fill-gaps 28859088 10000` means "find gaps in ingested ledgers in the range from ledger 28859088 to 28859088 + 10000 and fill them"

It's handy tool, because since we ditched generating ids by Astrologer, we can't just reingest big ranges to fill any gaps existed there